### PR TITLE
Proposed changes to use GPG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim
 
 RUN apt-get update -qqy \
   && DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-    moreutils \
+    moreutils gnupg \
   && apt-get -qqy clean all \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/README.rst
+++ b/README.rst
@@ -38,11 +38,71 @@ How to run?
    . ./venv/bin/activate
    pip install .
 
-   trace-poc submit <path_to_directory>
+
+   # Generate GPG key
+   gpg --full-generate-key
+   gpg --list-keys
+
+   # Configure docker-compose.yml
+   ...
+   - GPG_FINGERPRINT=your_fingerprint
+   - GPG_PASSPHRASE=your_passphrase
+   ...
 
    # for server
    docker-compose up  # needs v2.x
 
+   # Clone example
+   git clone https://github.com/labordynamicsinstitute/example-R-nodata
+   cd example-R-nodata
+
+   # Submit the run
+   trace-poc submit .
+
+   # Download the TRO
+   trace-poc download <run-id>
+
+   # Inspect the TRO
+   trace-pos inspect <download-path>
+
+   🔍 Inspecting /tmp/a9fc5aa5-b6bf-463a-8477-343f15ab53b9_run.zip
+	 ⭐ Bagging-Date - 2022-11-06
+	 ⭐ Bagging-Time - 15:30:52 UTC
+	 ⭐ DataAvailableAfterRuntime - Yes
+	 ⭐ DataAvailablePriorToRuntime - Yes
+	 ⭐ InputsFromRepository - No
+	 ⭐ IntermediateStepsLevel - 0
+	 ⭐ NetworkIsolation - Yes
+	 ⭐ PreventsAuthorInteraction - Yes
+	 ⭐ RuntimeEvidence - Yes
+	 ⭐ TRACEOrganization - UIUC
+	 ⭐ TRACESystem - TRACE Prototype
+	 ⭐ TRACEVersion - 0.1
+	 ⭐ TROIncludesCode - Yes
+	 ⭐ TROIncludesOutputs - Yes
+	 ⭐ TracksIntermediateSteps - No
+
+    # Verify the TRO using API
+    trace-poc verify /tmp/a9fc5aa5-b6bf-463a-8477-343f15ab53b9_run.zip
+    Signature info:
+	creation_date: 2022-11-06
+	timestamp: 1667748652
+	keyid: F35DE0EBFE748EC4
+	username: TRACE POC (TRACE System Proof of Concept) <trace-poc@gmail.com>
+	status: signature valid
+	fingerprint: 9C71A9331A94D28DA4D56A98F35DE0EBFE748EC4
+	expiry: 0
+	pubkey_fingerprint: 9C71A9331A94D28DA4D56A98F35DE0EBFE748EC4
+	trust_level: 4
+	trust_text: TRUST_ULTIMATE
+    ✨ Valid and signed bag
+
+    # Verify the TRO locally (assumes key has been imported + trusted)
+    $ unzip -qz /tmp/a9fc5aa5-b6bf-463a-8477-343f15ab53b9_run.zip > /tmp/tro.sig
+    $ gpg --verify /tmp/tro.sig
+    gpg: Signature made Sun Nov  6 15:30:52 2022 UTC
+    gpg:                using RSA key 9C71A9331A94D28DA4D56A98F35DE0EBFE748EC4
+    gpg: Good signature from "TRACE POC (TRACE System Proof of Concept) <trace-poc@gmail.com>" [ultimate]
 
 Credits
 -------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,16 @@ services:
     environment:
       - TRACE_CERTS_PATH=/etc/trace_certs
       - TRACE_STORAGE_PATH=/srv
+      - GPG_HOME=/etc/gpg
+      - GPG_FINGERPRINT=your_key_fingerprint
+      - GPG_PASSPHRASE=your_key_passphrase
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
       - /usr/bin/docker:/usr/bin/docker
       - ./volumes/storage:/srv
       - ./volumes/certs:/etc/trace_certs
+      - /home/ubuntu/.gnupg:/etc/gpg
     cap_add:
       - SYS_ADMIN
     security_opt:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ twine==1.14.0
 Click==7.1.2
 pytest==6.2.4
 black==21.7b0
+python-gnupg==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     "docker>=2.3.0",
     "cryptography",
     "bdbag",
+    "python-gnupg",
 ]
 
 test_requirements = [


### PR DESCRIPTION
Updates POC to use GPG.

* Use GPG externally to generate key with passphrase
* Configure docker-compose to use specified fingerprint and passphrase
* Attached signature embedded in Zip comment
* Can verify via API or locally

Here's my POC claims file, if useful, based on queries spreadsheet:
```
cat volumes/certs/claims.json
{
    "TRACESystem": "TRACE Prototype",
    "TRACEVersion": "0.1",
    "TRACEOrganization": "UIUC",
    "DataAvailablePriorToRuntime": "Yes",
    "DataAvailableAfterRuntime": "Yes",
    "TROIncludesOutputs": "Yes",
    "TROIncludesCode": "Yes",
    "NetworkIsolation": "Yes",
    "PreventsAuthorInteraction": "Yes",
    "InputsFromRepository": "No",
    "TracksIntermediateSteps": "No",
    "IntermediateStepsLevel": "0",
    "RuntimeEvidence": "Yes"
}
```